### PR TITLE
[DS-1315] Update PanModal to fix bottom sheet width to 600 pt on iPad

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -40,6 +40,7 @@ open class PanModalPresentationController: UIPresentationController {
         static let indicatorYOffset = CGFloat(8.0)
         static let snapMovementSensitivity = CGFloat(0.7)
         static let dragIndicatorSize = CGSize(width: 36.0, height: 5.0)
+        static let maximumiPadWidth = CGFloat(600.0)
     }
 
     // MARK: - Properties
@@ -365,9 +366,18 @@ private extension PanModalPresentationController {
         presentedView.translatesAutoresizingMaskIntoConstraints = false
         topConstraint = presentedView.topAnchor.constraint(equalTo: containerView.topAnchor)
         topConstraint?.isActive = true
-        presentedView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor).isActive = true
-        presentedView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
         presentedView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor).isActive = true
+
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            presentedView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor).isActive = true
+            presentedView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
+        } else if UIDevice.current.userInterfaceIdiom == .pad {
+            presentedView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maximumiPadWidth).isActive = true
+            presentedView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
+        }
+
+        setNeedsLayoutUpdate()
+        presentedView.layoutIfNeeded()
 
         if presentable.showDragIndicator {
             addDragIndicatorView(to: presentedView)

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -178,6 +178,16 @@ open class PanModalPresentationController: UIPresentationController {
         configureViewLayout()
     }
 
+    override public func containerViewDidLayoutSubviews() {
+        super.containerViewDidLayoutSubviews()
+
+        guard let presentable = presentable else { return }
+
+        if presentable.shouldRoundTopCorners {
+            addRoundedCorners(to: presentedView)
+        }
+    }
+
     override public func presentationTransitionWillBegin() {
 
         guard let containerView = containerView
@@ -372,19 +382,12 @@ private extension PanModalPresentationController {
             presentedView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor).isActive = true
             presentedView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
         } else if UIDevice.current.userInterfaceIdiom == .pad {
-            presentedView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maximumiPadWidth).isActive = true
+            presentedView.widthAnchor.constraint(equalToConstant: Constants.maximumiPadWidth).isActive = true
             presentedView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
         }
 
-        setNeedsLayoutUpdate()
-        presentedView.layoutIfNeeded()
-
         if presentable.showDragIndicator {
             addDragIndicatorView(to: presentedView)
-        }
-
-        if presentable.shouldRoundTopCorners {
-            addRoundedCorners(to: presentedView)
         }
 
         setNeedsLayoutUpdate()

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -40,7 +40,7 @@ open class PanModalPresentationController: UIPresentationController {
         static let indicatorYOffset = CGFloat(8.0)
         static let snapMovementSensitivity = CGFloat(0.7)
         static let dragIndicatorSize = CGSize(width: 36.0, height: 5.0)
-        static let maximumiPadWidth = CGFloat(600.0)
+        static let maximumIpadWidth = CGFloat(600.0)
     }
 
     // MARK: - Properties
@@ -382,7 +382,7 @@ private extension PanModalPresentationController {
             presentedView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor).isActive = true
             presentedView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
         } else if UIDevice.current.userInterfaceIdiom == .pad {
-            presentedView.widthAnchor.constraint(equalToConstant: Constants.maximumiPadWidth).isActive = true
+            presentedView.widthAnchor.constraint(equalToConstant: Constants.maximumIpadWidth).isActive = true
             presentedView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
         }
 


### PR DESCRIPTION
Constrains the bottom sheet presentation on iPad to be fixed to 600 pts wide.

As a consequence of constraining to 600 pt on iPad, we need to defer rounding the corners until after the container view lays out the subviews, this way the final `bounds` of the `presentedView` are final and can be used in the bezier path calculation for the rounded corners.

![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-13 at 18 34 26](https://user-images.githubusercontent.com/7070754/224855057-07808188-1a6a-40a1-8405-6cde1d8d2a98.png)

I will update our PanModal dependency in BOE via tuist after this is merged into `main`.