### PR TITLE
Add Mac Catalyst support to Etsy PanModal fork (bump platforms to v17)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,12 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
+// Bumped from 5.1 -> 5.9 to support the .macCatalyst(...) and .iOS(.v17) platform declarations below.
 
 import PackageDescription
 
 let package = Package(
     name: "PanModal",
-    platforms: [.iOS(.v10)],
+    platforms: [.iOS(.v17), .macCatalyst(.v17)],
     products: [
         .library(
             name: "PanModal",


### PR DESCRIPTION
## Summary
- Adds `.macCatalyst(.v17)` alongside `.iOS(.v17)` in `Package.swift` so this package builds for the Mac Catalyst variant, unblocking the standalone Mac build of the Collage style guide app (part of the broader Mac Catalyst enablement effort — 5 Etsy-owned SPM packages need this).
- Bumps `swift-tools-version` from `5.1` to `5.9`, required for the `.macCatalyst(...)` and `.iOS(.v17)` platform declarations.
- Bumped the iOS floor to `.v17` (rather than leaving it at `.v10`) since this fork is only consumed by EtsyApp, which already requires iOS 18+.

## Test plan
- [x] `git merge-base --is-ancestor 2322ef9cec54127b7ae69bbed01f8b598e35aca4 HEAD` — passes, Etsy base is now an ancestor
- [x] `completion:` overload confirmed present in `PanModal/Presenter/UIViewController+PanModalPresenter.swift`
- [x] `xcodebuild -scheme PanModal -destination 'generic/platform=iOS Simulator,name=iPhone 15' build` — succeeds (no regression)
- [x] `xcodebuild -scheme PanModal -destination 'generic/platform=macOS,variant=Mac Catalyst' build` — succeeds, no errors, no `#if targetEnvironment(macCatalyst)` guards needed
- [ ] Re-pin this revision in EtsyApp's `Tuist/Package.swift` and verify the Catalyst build end-to-end (tracked separately)